### PR TITLE
Improve php-fpm monitor script to support unix socket.

### DIFF
--- a/templates/agent/scripts/php-fpm.py.j2
+++ b/templates/agent/scripts/php-fpm.py.j2
@@ -13,10 +13,11 @@ import sys
 from distutils.spawn import find_executable
 
 
-HOST = "{{ zabbix_php_fpm.host }}"
-PORT = "{{ zabbix_php_fpm.port }}"
-SOCKET = "{{ zabbix_php_fpm.socket }}"  # Optional example: "/var/run/php5-fpm.sock"
-STATUS_URI = "{{ zabbix_php_fpm.status_uri }}"
+HOST = "{{ zabbix_php_fpm.host | default('') }}"
+PORT = "{{ zabbix_php_fpm.port | default('') }}"
+SOCKET = "{{ zabbix_php_fpm.socket | default('') }}"  # Optional example: "/var/run/php5-fpm.sock"
+
+STATUS_URI = "{{ zabbix_php_fpm.status_uri | default('')}}"
 
 # Environment variables are read by cgi-fcgi as input arguments.
 # The following are default config

--- a/templates/agent/scripts/php-fpm.py.j2
+++ b/templates/agent/scripts/php-fpm.py.j2
@@ -15,7 +15,7 @@ from distutils.spawn import find_executable
 
 HOST = "{{ zabbix_php_fpm.host }}"
 PORT = "{{ zabbix_php_fpm.port }}"
-SOCKET = "{{ zabbix_php_fpm.socket }}"  # Optional unix:/var/run/php5-fpm.sock
+SOCKET = "{{ zabbix_php_fpm.socket }}"  # Optional example: "/var/run/php5-fpm.sock"
 STATUS_URI = "{{ zabbix_php_fpm.status_uri }}"
 
 # Environment variables are read by cgi-fcgi as input arguments.
@@ -77,17 +77,13 @@ env = dict(os.environ)
 #  u'total processes': 2}
 
 
-def read_php_fpm_status(host, port):
-    host_port_string = "{host}:{port}".format(
-        host=host,
-        port=port,
-    )
+def read_php_fpm_status(address):
 
     if not find_executable("cgi-fcgi"):
         raise Exception("cgi-fcgi can not be found.")
 
     child = subprocess.Popen(
-        ['cgi-fcgi', '-bind', '-connect', host_port_string],
+        ['cgi-fcgi', '-bind', '-connect', address],
         env=env,
         stdout=subprocess.PIPE
     )
@@ -123,7 +119,17 @@ if __name__ == '__main__':
     else:
         arg = sys.argv[1]
         try:
-            result = read_php_fpm_status(HOST, PORT)
+            if SOCKET:
+                result = read_php_fpm_status(SOCKET)
+            elif HOST and PORT:
+                host_port_string = "{host}:{port}".format(
+                    host=HOST,
+                    port=PORT,
+                )
+                result = read_php_fpm_status(host_port_string)
+            else:
+                print "Check SOCKET, HOST and PORT."
+                exit(1)
         except Exception as e:
             print "Unexpected Error: %s" % e
             exit(1)


### PR DESCRIPTION
Previously, I only found the way to use cgi-fcgi tools to get response by sending fast cgi protocol using ip and port. I figured out it also support sending request to unix socket. Minor changes made without affecting the environment being deployed with previous version of this script.
